### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# strange-horizon
-[![GitHub](https://img.shields.io/github/license/halogeeni/strange-horizon)](https://github.com/halogeeni/strange-horizon/blob/master/LICENSE.md)
+# strange-horizon-api
+[![GitHub](https://img.shields.io/github/license/halogeeni/strange-horizon-api)](https://github.com/halogeeni/strange-horizon-api/blob/master/LICENSE.md)
 
 API for Strange Horizon record label. Work in progress.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,11 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.arasio.webdev.strangehorizon</groupId>
-  <artifactId>strange-horizon</artifactId>
+  <artifactId>strange-horizon-api</artifactId>
   <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
   <name>Strange Horizon API</name>
-  <url>https://github.com/halogeeni/strange-horizon</url>
+  <url>https://github.com/halogeeni/strange-horizon-api</url>
 
   <parent>
     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Add `-api` suffix to project naming, so it won't conflict with the client project.